### PR TITLE
Broaden Symfony console version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require" : {
         "php": ">=5.5.9",
-        "symfony/console": "^3.0",
+        "symfony/console": "^2.6|^3.0",
         "illuminate/support": "^5.2"
     },
     "autoload": {


### PR DESCRIPTION
I had some version conflicts with other globally installed packages.
